### PR TITLE
feat(platforms): use project-specific DBs

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -61,7 +61,9 @@ jobs:
       - name: platforms
         run: sh all.sh platforms
         env:
-          POSTGRESQL_URL: ${{ secrets.POSTGRESQL_URL }}
+          NETLIFY_PG_URL: ${{ secrets.NETLIFY_PG_URL }}
+          LAMBDA_PG_URL: ${{ secrets.LAMBDA_PG_URL }}
+          HEROKU_PG_URL: ${{ secrets.HEROKU_PG_URL }}
           NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
           HEROKU_API_KEY: ${{ secrets.HEROKU_API_KEY }}
           NPM_CONFIG_LOGLEVEL: error

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -61,6 +61,7 @@ jobs:
       - name: platforms
         run: sh all.sh platforms
         env:
+          POSTGRESQL_URL: ${{ secrets.POSTGRESQL_URL }}
           NETLIFY_PG_URL: ${{ secrets.NETLIFY_PG_URL }}
           LAMBDA_PG_URL: ${{ secrets.LAMBDA_PG_URL }}
           HEROKU_PG_URL: ${{ secrets.HEROKU_PG_URL }}

--- a/platforms/heroku/prisma/photonjs/schema.prisma
+++ b/platforms/heroku/prisma/photonjs/schema.prisma
@@ -1,7 +1,7 @@
 datasource db {
     provider = "postgresql"
     // Like, postgresql://user:password@localhost:5432/database/schema
-    url      = env("HEROKU_PG_URL")
+    url      = env("POSTGRESQL_URL")
 }
 
 generator photon {

--- a/platforms/heroku/prisma/photonjs/schema.prisma
+++ b/platforms/heroku/prisma/photonjs/schema.prisma
@@ -1,7 +1,7 @@
 datasource db {
     provider = "postgresql"
     // Like, postgresql://user:password@localhost:5432/database/schema
-    url      = env("POSTGRESQL_URL")
+    url      = env("HEROKU_PG_URL")
 }
 
 generator photon {

--- a/platforms/heroku/prisma/schema.prisma
+++ b/platforms/heroku/prisma/schema.prisma
@@ -1,7 +1,7 @@
 datasource db {
     provider = "postgresql"
     // Like, postgresql://user:password@localhost:5432/database/schema
-    url      = env("HEROKU_PG_URL")
+    url      = env("POSTGRESQL_URL")
 }
 
 generator photon {

--- a/platforms/heroku/prisma/schema.prisma
+++ b/platforms/heroku/prisma/schema.prisma
@@ -1,7 +1,7 @@
 datasource db {
     provider = "postgresql"
     // Like, postgresql://user:password@localhost:5432/database/schema
-    url      = env("POSTGRESQL_URL")
+    url      = env("HEROKU_PG_URL")
 }
 
 generator photon {

--- a/platforms/lambda/prisma/schema.prisma
+++ b/platforms/lambda/prisma/schema.prisma
@@ -5,7 +5,7 @@ generator photon {
 
 datasource db {
 	provider = "postgresql"
-	url      = env("POSTGRESQL_URL")
+	url      = env("LAMBDA_PG_URL")
 }
 
 model User {

--- a/platforms/lambda/run.sh
+++ b/platforms/lambda/run.sh
@@ -3,7 +3,7 @@
 set -eux
 
 # this just verifies environment variables are set
-x="$POSTGRESQL_URL"
+x="$LAMBDA_PG_URL"
 x="$AWS_DEFAULT_REGION"
 x="$AWS_ACCESS_KEY_ID"
 x="$AWS_SECRET_ACCESS_KEY"

--- a/platforms/lambda/update-code.sh
+++ b/platforms/lambda/update-code.sh
@@ -4,7 +4,7 @@ set -eux
 
 sh zip.sh
 
-aws lambda update-function-configuration --function-name prisma2-e2e-tests --environment "Variables={POSTGRESQL_URL=$POSTGRESQL_URL}" --timeout 10
+aws lambda update-function-configuration --function-name prisma2-e2e-tests --environment "Variables={LAMBDA_PG_URL=$LAMBDA_PG_URL}" --timeout 10
 
 aws lambda update-function-code --function-name prisma2-e2e-tests --zip-file "fileb://lambda.zip"
 yarn install --offline

--- a/platforms/netlify/prisma/schema.prisma
+++ b/platforms/netlify/prisma/schema.prisma
@@ -1,7 +1,7 @@
 datasource db {
   provider = "postgresql"
   // Like, postgresql://user:password@localhost:5432/database/schema
-  url      = env("POSTGRESQL_URL")
+  url      = env("NETLIFY_PG_URL")
 }
 
 generator photon {

--- a/platforms/netlify/run.sh
+++ b/platforms/netlify/run.sh
@@ -2,9 +2,6 @@
 
 set -eu
 
-rm -rf prisma/migrations/
-rm -rf prisma/dev.db
-
 yarn install
 yarn prisma2 generate
 


### PR DESCRIPTION
This makes sure #6 will work without conflicts by giving every project its own DB.