### PR TITLE
netlify-zisi: define ZISI_VERSION in code

### DIFF
--- a/platforms/netlify-zisi/netlify.toml
+++ b/platforms/netlify-zisi/netlify.toml
@@ -1,2 +1,6 @@
 [build]
 functions = "functions/"
+
+[build.environment]
+  # Fix to ensure the Prisma binary is packaged with the lambda function
+  ZISI_VERSION = "0.4.0-9"


### PR DESCRIPTION
This is to ensure the tests don't require setting it manually in the Netlify site